### PR TITLE
Updating the theme as per the changes to the upstream theme

### DIFF
--- a/commandline.tmpl
+++ b/commandline.tmpl
@@ -43,14 +43,14 @@ kubectl config set-cluster {{ .ClusterName }} \
   --server={{ .APIServerURL }} \
   --embed-certs=true \
   --certificate-authority=/tmp/ca-{{ .ClusterName }}.pem
-kubectl config set-credentials {{ .ClusterName }}-{{ .Email }}  \
+kubectl config set-credentials {{ .KubeCfgUser }}  \
   --auth-provider=oidc  \
   --auth-provider-arg=idp-issuer-url={{ .IssuerURL }}  \
   --auth-provider-arg=client-id={{ .ClientID }}  \
   --auth-provider-arg=client-secret={{ .ClientSecret }} \
   --auth-provider-arg=refresh-token={{ .RefreshToken }} \
   --auth-provider-arg=id-token={{ .IDToken }}
-kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .ClusterName }}-{{ .Email }}
+kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .ClusterName }}-{{ .KubeCfgUser }}
 kubectl config use-context {{ .ClusterName }}
     </code></pre>
     <p>Lokomotive Kubernetes by <a href="https://kinvolk.io">Kinvolk</a>. Built with <a href="https://github.com/heptiolabs/gangway">Gangway</a>, Apache-2.0</p>


### PR DESCRIPTION
Fixes #2 

Currently nothing gets printed after `kubectl config set-credentials`

Incorrect:
```
echo "-----BEGIN CERTIFICATE-----
OUTPUT REMOVED
-----END CERTIFICATE-----
" \ > /tmp/ca-paris.pem
kubectl config set-cluster paris \
  --server=https://<cluster-domain-name>:6443 \
  --embed-certs=true \
  --certificate-authority=/tmp/ca-paris.pem
kubectl config set-credentials paris-
```
Correct: 

```
echo "-----BEGIN CERTIFICATE-----
OUTPUT REMOVED
-----END CERTIFICATE-----
" \ > /tmp/ca-paris.pem
kubectl config set-cluster paris \
  --server=https://<cluster-domain-name>:6443 \
  --embed-certs=true \
  --certificate-authority=/tmp/ca-paris.pem
kubectl config set-credentials email@cluster-name \
  --auth-provider=oidc  \
  --auth-provider-arg=idp-issuer-url=<issuer-url>  \
  --auth-provider-arg=client-id=<secret-id>  \
  --auth-provider-arg=client-secret=<client-secret> \
  --auth-provider-arg=refresh-token= <client-token> \
  --auth-provider-arg=id-token=<output removed>
kubectl config set-context paris --cluster=paris --user=paris-
```
Signed-off-by: Imran Pochi <imran@kinvolk.io>